### PR TITLE
Fix CSS scoping for chatbot

### DIFF
--- a/main.html
+++ b/main.html
@@ -1,19 +1,22 @@
 <!-- 노피 AI 챗봇 전체 코드 -->
-<div class="nofee-chatbot-wrapper">
+<div class="nofee-chatbot-wrapper" style="background:#fff; position:relative; z-index:1;">
     <!-- CSS -->
     <style>
-        * {
+        .nofee-chatbot-wrapper,
+        .nofee-chatbot-wrapper * {
             margin: 0;
             padding: 0;
             box-sizing: border-box;
         }
 
-        body {
+        .nofee-chatbot-wrapper {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            background: linear-gradient(135deg, #0f0c29 0%, #302b63 50%, #24243e 100%);
             color: #333;
             line-height: 1.6;
             min-height: 100vh;
+            background: #fff;
+            position: relative;
+            isolation: isolate;
         }
 
         .container {
@@ -23,12 +26,12 @@
             min-height: 100vh;
             display: flex;
             flex-direction: column;
+            background: linear-gradient(135deg, #0f0c29 0%, #302b63 50%, #24243e 100%);
         }
 
         .header {
-            background: rgba(255, 255, 255, 0.1);
-            backdrop-filter: blur(10px);
-            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.95);
+            border: 1px solid rgba(255, 255, 255, 0.3);
             color: white;
             padding: 30px;
             text-align: center;
@@ -160,13 +163,12 @@
         .bot-avatar {
             width: 40px;
             height: 40px;
-            background: rgba(255, 255, 255, 0.2);
+            background: rgba(255, 255, 255, 0.8);
             border-radius: 50%;
             display: flex;
             align-items: center;
             justify-content: center;
             font-size: 20px;
-            backdrop-filter: blur(10px);
             box-shadow: 0 0 20px rgba(255, 255, 255, 0.3);
         }
 


### PR DESCRIPTION
## Summary
- scope all CSS rules inside `.nofee-chatbot-wrapper`
- remove blur effects
- keep gradient only for chatbot container
- add inline wrapper styles

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_68401bbaa680832b8312fb7d8ea5d0bf