### PR TITLE
Add local fallback for chatbot

### DIFF
--- a/main.html
+++ b/main.html
@@ -167,47 +167,50 @@
             }
         }
         
+        // 공통 초기화 함수
+        function initNofee() {
+            console.log('main.js 로드 완료');
+
+            if (window.NofeeAI && typeof window.NofeeAI.init === 'function') {
+                console.log('노피 AI 초기화 시작');
+
+                document.getElementById('homeBtn').onclick = function() {
+                    if (window.NofeeAI) window.NofeeAI.resetChat();
+                };
+                document.getElementById('phoneBtn').onclick = function() {
+                    if (window.NofeeAI) window.NofeeAI.showPhoneList();
+                };
+                document.getElementById('deliveryBtn').onclick = function() {
+                    if (window.NofeeAI) window.NofeeAI.showDeliveryInfo();
+                };
+
+                window.NofeeAI.init();
+            } else {
+                console.error('NofeeAI 객체를 찾을 수 없습니다');
+                document.getElementById('nofeeLoading').innerHTML =
+                    '<p>초기화에 실패했습니다.</p>' +
+                    '<button onclick="location.reload()" style="margin-top: 10px; padding: 8px 16px; background: #5C5CFF; color: white; border: none; border-radius: 20px; cursor: pointer;">새로고침</button>';
+            }
+        }
+
         // 스크립트 로드
         function loadNofeeScript() {
-            const script = document.createElement('script');
-            script.src = 'https://cdn.jsdelivr.net/gh/Jacob-PO/nofee_chat@main/main.js?v=' + Date.now();
-            
-            script.onload = function() {
-                console.log('main.js 로드 완료');
-                
-                // 바로 초기화 시도
+            function appendScript(src, callback) {
+                const s = document.createElement('script');
+                s.src = src;
+                s.onload = callback;
+                s.onerror = callback;
+                document.body.appendChild(s);
+            }
+
+            appendScript('https://cdn.jsdelivr.net/gh/Jacob-PO/nofee_chat@main/main.js?v=' + Date.now(), function() {
                 if (window.NofeeAI && typeof window.NofeeAI.init === 'function') {
-                    console.log('노피 AI 초기화 시작');
-                    
-                    // 버튼 이벤트 연결
-                    document.getElementById('homeBtn').onclick = function() {
-                        if (window.NofeeAI) window.NofeeAI.resetChat();
-                    };
-                    document.getElementById('phoneBtn').onclick = function() {
-                        if (window.NofeeAI) window.NofeeAI.showPhoneList();
-                    };
-                    document.getElementById('deliveryBtn').onclick = function() {
-                        if (window.NofeeAI) window.NofeeAI.showDeliveryInfo();
-                    };
-                    
-                    // 초기화
-                    window.NofeeAI.init();
+                    initNofee();
                 } else {
-                    console.error('NofeeAI 객체를 찾을 수 없습니다');
-                    document.getElementById('nofeeLoading').innerHTML = 
-                        '<p>초기화에 실패했습니다.</p>' +
-                        '<button onclick="location.reload()" style="margin-top: 10px; padding: 8px 16px; background: #5C5CFF; color: white; border: none; border-radius: 20px; cursor: pointer;">새로고침</button>';
+                    console.warn('원격 스크립트 로드 실패, 로컬 파일 시도');
+                    appendScript('main.js?v=' + Date.now(), initNofee);
                 }
-            };
-            
-            script.onerror = function() {
-                console.error('main.js 로드 실패');
-                document.getElementById('nofeeLoading').innerHTML = 
-                    '<p>스크립트 로드에 실패했습니다.</p>' +
-                    '<button onclick="location.reload()" style="margin-top: 10px; padding: 8px 16px; background: #5C5CFF; color: white; border: none; border-radius: 20px; cursor: pointer;">새로고침</button>';
-            };
-            
-            document.body.appendChild(script);
+            });
         }
         
         // 즉시 실행


### PR DESCRIPTION
## Summary
- load chatbot script from CDN with local fallback
- allow item and region data to load from CDN, GitHub, or local files

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68405131697c832b932bcf91a54e8113