### PR TITLE
Load main.js from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 ## 파일 구조
 - `main.html` – Webflow에 그대로 임베드할 수 있는 완전한 챗봇 코드
-- `main.js` – 챗봇 동작 스크립트(외부 호스팅용)
+- `main.js` – 챗봇 동작 스크립트(자동 로드)
 - `item.json` – 스마트폰 상품 데이터
 - `regions.json` – 지역 데이터
 
 ## 사용 방법
-1. `main.html` 파일의 전체 코드를 Webflow의 **Code Embed** 요소에 붙여넣습니다.
+1. `main.html` 파일의 전체 코드를 Webflow의 **Code Embed** 요소에 붙여넣습니다. 이 파일은 `main.js`를 GitHub에서 자동으로 로드하므로 추가 업로드가 필요하지 않습니다.
 2. `item.json`과 `regions.json` 파일은 GitHub/jsDelivr 등에 업로드한 뒤 `window.NOFEE_BASE_URL` 값을 변경해 불러올 수 있습니다.
 3. Webflow에 `Chat Form`이라는 이름의 폼을 생성하고 필요한 필드를 hidden input으로 추가합니다.
 4. 사이트를 퍼블리시한 후 챗봇이 정상적으로 동작하는지 확인합니다.

--- a/main.html
+++ b/main.html
@@ -483,6 +483,60 @@
     <input type="hidden" name="product_json" id="product_json">
   </form>
 
-  <!-- main.js 로드 -->
-  <script src="main.js"></script>
+  <!-- ─────────── main.js 로드 (GitHub Raw → 실패 시 GitHub CDN) ─────────── -->
+  <script>
+    // 전역 객체로 노출
+    window.NofeeAI = window.NofeeAI || {};
+
+    // CORS 및 캐시 설정
+    window.NofeeAI.fetchOptions = {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+      cache: 'no-cache'
+    };
+
+    // main.js 로드 (GitHub Raw URL 우선 → 실패 시 GitHub CDN)
+    ;(function() {
+      let scriptLoaded = false;
+
+      function loadScript(url, isBackup) {
+        if (scriptLoaded) return;
+        const script = document.createElement('script');
+        script.src = url + '?v=' + Date.now();
+        script.async = true;
+
+        script.onload = function() {
+          scriptLoaded = true;
+          console.log('Nofee AI 스크립트 로드 완료' + (isBackup ? ' (백업)' : ''));
+          if (window.NofeeAI && typeof window.NofeeAI.init === 'function') {
+            setTimeout(() => window.NofeeAI.init(), 100);
+          }
+        };
+
+        script.onerror = function() {
+          console.error('Nofee AI 스크립트 로드 실패:', url);
+          if (!isBackup) {
+            // GitHub Raw가 실패하면 GitHub CDN으로 재시도
+            setTimeout(() => {
+              const cdnUrl = 'https://gitcdn.link/repo/Jacob-PO/nofee_chat/main/main.js';
+              loadScript(cdnUrl, true);
+            }, 500);
+          } else {
+            // 모든 시도 실패 시 에러 메시지 출력
+            const container = document.getElementById('nofee-chat-container');
+            if (container) {
+              container.innerHTML =
+                '<div style="padding:20px; text-align:center; color:#666;">챗봇을 불러올 수 없습니다. 페이지를 새로고침해주세요.</div>';
+            }
+          }
+        };
+
+        document.head.appendChild(script);
+      }
+
+      // 먼저 GitHub Raw에서 불러오기
+      const rawUrl = 'https://raw.githubusercontent.com/Jacob-PO/nofee_chat/main/main.js';
+      loadScript(rawUrl, false);
+    })();
+  </script>
 </div>


### PR DESCRIPTION
## Summary
- update embed HTML to dynamically load `main.js` from GitHub with a CDN fallback
- document automatic script loading in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6840f218b148832b984b5063b9dca05a