### PR TITLE
Fix remote script URL

### DIFF
--- a/main.html
+++ b/main.html
@@ -518,7 +518,7 @@
           if (!isBackup) {
             // GitHub Raw가 실패하면 GitHub CDN으로 재시도
             setTimeout(() => {
-            const cdnUrl = 'https://gitcdn.link/repo/Jacob-PO/nofee_chat/main.js';
+            const cdnUrl = 'https://cdn.jsdelivr.net/gh/Jacob-PO/nofee_chat@main/main.js';
               loadScript(cdnUrl, true);
             }, 500);
           } else {
@@ -535,7 +535,7 @@
       }
 
       // 먼저 GitHub Raw에서 불러오기
-      const rawUrl = 'https://raw.githubusercontent.com/Jacob-PO/nofee_chat/main.js';
+      const rawUrl = 'https://raw.githubusercontent.com/Jacob-PO/nofee_chat/main/main.js';
       loadScript(rawUrl, false);
     })();
   </script>


### PR DESCRIPTION
## Summary
- correct the main.js raw URL in `main.html`
- switch CDN fallback to jsDelivr

## Testing
- `node -c main.js`


------
https://chatgpt.com/codex/tasks/task_b_6840f6629350832ba1ef23c6eff3a881